### PR TITLE
fix VERSION constant namespace module name

### DIFF
--- a/lib/omniauth/microsoft_graph/version.rb
+++ b/lib/omniauth/microsoft_graph/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module MicrosoftGraph
     VERSION = "0.3.3"
   end

--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/microsoft_graph/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-microsoft_graph"
-  spec.version       = Omniauth::MicrosoftGraph::VERSION
+  spec.version       = OmniAuth::MicrosoftGraph::VERSION
   spec.authors       = ["Peter Philips", "Joel Van Horn"]
   spec.email         = ["pete@p373.net", "joel@joelvanhorn.com"]
   spec.summary       = %q{omniauth provider for Microsoft Graph}


### PR DESCRIPTION
[omniauth.gem defines `OmniAuth` module (not `Omniauth`).](https://github.com/omniauth/omniauth/blob/v2.0.4/lib/omniauth.rb#L5)

[`OmniAuth::Strategies::MicrosoftGraph` is also in `OmniAuth` module.](https://github.com/synth/omniauth-microsoft_graph/blob/1.0.0/lib/omniauth/strategies/microsoft_graph.rb#L3)

But `VERSION` constant is not in `OmniAuth` module. This pull-request fixes it.
