### PR TITLE
use userPrincipalName as info.email

### DIFF
--- a/lib/omniauth/strategies/microsoft_graph.rb
+++ b/lib/omniauth/strategies/microsoft_graph.rb
@@ -27,7 +27,7 @@ module OmniAuth
 
       info do
         {
-          'email' => raw_info["mail"],
+          'email' => raw_info["userPrincipalName"],
           'first_name' => raw_info["givenName"],
           'last_name' => raw_info["surname"],
           'name' => [raw_info["givenName"], raw_info["surname"]].join(' '),
@@ -54,7 +54,7 @@ module OmniAuth
 
           session['omniauth.state'] = params[:state] if params[:state]
         end
-      end     
+      end
 
       def raw_info
         @raw_info ||= access_token.get('https://graph.microsoft.com/v1.0/me').parsed
@@ -62,7 +62,7 @@ module OmniAuth
 
       def callback_url
         options[:callback_url] || full_host + script_name + callback_path
-      end  
+      end
 
       def custom_build_access_token
         access_token = get_access_token(request)
@@ -119,7 +119,7 @@ module OmniAuth
         raw_response = client.request(:get, 'https://graph.microsoft.com/v1.0/me',
                                       params: { access_token: access_token }).parsed
         (raw_response['aud'] == options.client_id) || options.authorized_client_ids.include?(raw_response['aud'])
-      end              
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
+++ b/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
@@ -272,7 +272,7 @@ describe OmniAuth::Strategies::MicrosoftGraph do
 
     context 'with verified email' do
       let(:response_hash) do
-        { mail: 'something@domain.invalid' }
+        { userPrincipalName: 'something@domain.invalid' }
       end
 
       it 'should return equal email ' do


### PR DESCRIPTION
Hello, thank you for creating great gem!

I'm developing Microsoft Graph API using this gem. I've found some Microsoft Account does not have info.email property. I guess this can regenerate when you signed in as personal(not organization) Microsoft Account.

I've also found `userPrincipalName` has always been returned whether personal or organication account. So I have changed a variable from `mail` to `userPrincipalName` that assigns for info.email.

Thanks.