### PR TITLE
Relax omniauth dependency

### DIFF
--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'omniauth', '~> 2.0.4'
+  spec.add_runtime_dependency 'omniauth', '~> 2.0'
   spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
   spec.add_development_dependency "sinatra", '~> 0'
   spec.add_development_dependency "rake", '~> 12.3.3', '>= 12.3.3'


### PR DESCRIPTION
Omniauth [released minor version 2.1.0](https://github.com/omniauth/omniauth/releases/tag/v2.1.0) but previous dependency only allowed patch version bumps.

Relaxing this so the gem can be run alongside Omniauth 2.1.0 and brings it in line with other popular Omniauth strategies

cc @synth 