### PR TITLE
Update omniauth-oauth2 to support Oauth2 v2

### DIFF
--- a/lib/omniauth/microsoft_graph/version.rb
+++ b/lib/omniauth/microsoft_graph/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module MicrosoftGraph
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
   spec.add_development_dependency "sinatra", '~> 0'
   spec.add_development_dependency "rake", '~> 12.3.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
+++ b/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
@@ -267,7 +267,7 @@ describe OmniAuth::Strategies::MicrosoftGraph do
         end
       end
     end
-    let(:access_token) { OAuth2::AccessToken.from_hash(client, {}) }
+    let(:access_token) { OAuth2::AccessToken.from_hash(client, { 'access_token' => 'a' }) }
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 
     context 'with verified email' do
@@ -291,7 +291,7 @@ describe OmniAuth::Strategies::MicrosoftGraph do
         end
       end
     end
-    let(:access_token) { OAuth2::AccessToken.from_hash(client, {}) }
+    let(:access_token) { OAuth2::AccessToken.from_hash(client, { 'access_token' => 'a' }) }
 
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 


### PR DESCRIPTION
Address the EOL of Oauth2 version 1.4.10:

```
Post-install message from oauth2:

You have installed oauth2 version 1.4.10, which is EOL.
No further support is anticipated for the 1.4.x series.

OAuth2 version 2 is released.
There are BREAKING changes, but most will not encounter them, and upgrading should be easy!

Please see:
• https://github.com/oauth-xx/oauth2#what-is-new-for-v20
• https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md

Please upgrade, report issues, and support the project! Thanks, |7eter l-|. l3oling
```

This change is running in a production environment without issues.