### PR TITLE
use userPrincipalName as email fallback

### DIFF
--- a/lib/omniauth/strategies/microsoft_graph.rb
+++ b/lib/omniauth/strategies/microsoft_graph.rb
@@ -27,7 +27,7 @@ module OmniAuth
 
       info do
         {
-          'email' => raw_info["mail"],
+          'email' => raw_info["mail"] || raw_info["userPrincipalName"],
           'first_name' => raw_info["givenName"],
           'last_name' => raw_info["surname"],
           'name' => [raw_info["givenName"], raw_info["surname"]].join(' '),


### PR DESCRIPTION
I've found some Microsoft Account does not have info.email property. 

fixes https://github.com/synth/omniauth-microsoft_graph/issues/17 and solves https://github.com/synth/omniauth-microsoft_graph/pull/28