### PR TITLE
Fix email domain up domain case sensitive comparison

### DIFF
--- a/lib/omniauth/microsoft_graph/domain_verifier.rb
+++ b/lib/omniauth/microsoft_graph/domain_verifier.rb
@@ -37,7 +37,7 @@ module OmniAuth
         # This means while it's not suitable for consistently identifying a user
         # (the domain might change), it is suitable for verifying membership in
         # a given domain.
-        return true if email_domain == upn_domain ||
+        return true if email_domain.casecmp?(upn_domain) ||
           skip_verification == true ||
           (skip_verification.is_a?(Array) && skip_verification.include?(email_domain)) ||
           domain_verified_jwt_claim

--- a/spec/omniauth/microsoft_graph/domain_verifier_spec.rb
+++ b/spec/omniauth/microsoft_graph/domain_verifier_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe OmniAuth::MicrosoftGraph::DomainVerifier do
       it { is_expected.to be_truthy }
     end
 
+    context 'when email domain and userPrincipalName domain match but have different casing' do
+      let(:email) { 'foo@example.com' }
+      let(:upn) { 'bar@EXAMPLE.COM' }
+
+      it { is_expected.to be_truthy }
+    end
+
     context 'when domain validation is disabled' do
       let(:options) { super().merge(skip_domain_verification: true) }
 


### PR DESCRIPTION
Hi,

This patch addresses https://github.com/synth/omniauth-microsoft_graph/issues/41

We have customers failing to complete OAuth because their UPN Domain is some cased variation of their email domain, for example, the email is `jon@mydomain.com`, then the UPN domain is `MyDomain.com`.