### PR TITLE
Restrict gemspec to Oauth gem <= 2.0.10

### DIFF
--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jwt', '~> 2.0'
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
   spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
+  spec.add_runtime_dependency 'oauth2',  [">= 2.0.2", "< 2.0.10"]
   spec.add_development_dependency "sinatra", '~> 2.2'
   spec.add_development_dependency "rake", '~> 12.3.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
Oauth2 version 2.0.10 introduced a breaking change that breaks this gem, this PR restricts the dependency to the last known working version

closes #43 