### PR TITLE
Support entra ID Yammer app

### DIFF
--- a/lib/omniauth/strategies/microsoft_graph.rb
+++ b/lib/omniauth/strategies/microsoft_graph.rb
@@ -11,8 +11,8 @@ module OmniAuth
 
       option :client_options, {
         site:          'https://login.microsoftonline.com/',
-        token_url:     'common/oauth2/v2.0/token',
-        authorize_url: 'common/oauth2/v2.0/authorize'
+        token_url:     'organizations/oauth2/v2.0/token',
+        authorize_url: 'organizations/oauth2/v2.0/authorize'
       }
 
       option :authorize_options, %i[state callback_url access_type display score auth_type scope prompt login_hint domain_hint response_mode]

--- a/lib/omniauth/strategies/microsoft_graph.rb
+++ b/lib/omniauth/strategies/microsoft_graph.rb
@@ -13,8 +13,8 @@ module OmniAuth
 
       option :client_options, {
         site:          'https://login.microsoftonline.com/',
-        token_url:     'organizations/oauth2/v2.0/token',
-        authorize_url: 'organizations/oauth2/v2.0/authorize'
+        token_url:     'common/oauth2/v2.0/token',
+        authorize_url: 'common/oauth2/v2.0/authorize'
       }
 
       option :authorize_options, %i[state callback_url access_type display score auth_type scope prompt login_hint domain_hint response_mode]

--- a/lib/omniauth/strategies/microsoft_graph.rb
+++ b/lib/omniauth/strategies/microsoft_graph.rb
@@ -6,6 +6,8 @@ module OmniAuth
       BASE_SCOPE_URL = 'https://graph.microsoft.com/'
       BASE_SCOPES = %w[offline_access openid email profile].freeze
       DEFAULT_SCOPE = 'offline_access openid email profile User.Read'.freeze
+      YAMMER_PROFILE_URL = 'https://www.yammer.com/api/v1/users/current.json'
+      MICROSOFT_GRAPH_PROFILE_URL = 'https://graph.microsoft.com/v1.0/me'
 
       option :name, :microsoft_graph
 
@@ -64,7 +66,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://graph.microsoft.com/v1.0/me').parsed
+        @raw_info ||= access_token.get(profile_endpoint).parsed
       end
 
       def callback_url
@@ -73,10 +75,24 @@ module OmniAuth
 
       def custom_build_access_token
         access_token = get_access_token(request)
+        # Get the profile(microsoft graph / yammer) endpoint choice based on returned bearer token
+        @profile_endpoint = determine_profile_endpoint(request)
         access_token
       end
 
       alias build_access_token custom_build_access_token
+
+      def profile_endpoint
+        @profile_endpoint ||= MICROSOFT_GRAPH_PROFILE_URL
+      end
+
+      def determine_profile_endpoint(request)
+        if request.env['omniauth.params']['scope']&.include? 'yammer'
+          YAMMER_PROFILE_URL
+        else
+          MICROSOFT_GRAPH_PROFILE_URL
+        end
+      end
 
       private
 


### PR DESCRIPTION
Auth 2.0 authentication for Yammer is deprecated. Now to access legacy Viva Engage ( Yammer ) APIs, it is recommended to use Yammer API registered via Azure Portal. This PR kind of differentiates between Microsoft graph and Yammer profile,  so bearer token returned does not throw **invalid audience** error. We supply explicit yammer scopes before applying for bearer token. 
