### PR TITLE
Revert omniauth labels

### DIFF
--- a/example/example.rb
+++ b/example/example.rb
@@ -10,7 +10,7 @@ client_id = ENV['AZURE_APPLICATION_CLIENT_ID']
 secret = ENV['AZURE_APPLICATION_CLIENT_SECRET']
 
 use Rack::Session::Cookie
-use OmniAuth::Builder do
+use Omniauth::Builder do
   provider :microsoft_graph, client_id, secret
 end
 

--- a/lib/omniauth/microsoft_graph/version.rb
+++ b/lib/omniauth/microsoft_graph/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module MicrosoftGraph
-    VERSION = "2.0.2"
+    VERSION = "0.3.3"
   end
 end

--- a/lib/omniauth/microsoft_graph/version.rb
+++ b/lib/omniauth/microsoft_graph/version.rb
@@ -1,4 +1,4 @@
-module OmniAuth
+module Omniauth
   module MicrosoftGraph
     VERSION = "2.0.2"
   end

--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/microsoft_graph/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-microsoft_graph"
-  spec.version       = OmniAuth::MicrosoftGraph::VERSION
+  spec.version       = Omniauth::MicrosoftGraph::VERSION
   spec.authors       = ["Peter Philips", "Joel Van Horn"]
   spec.email         = ["pete@p373.net", "joel@joelvanhorn.com"]
   spec.summary       = %q{omniauth provider for Microsoft Graph}


### PR DESCRIPTION
Reverting gem labels from "OmniAuth 2.0.2" to "Omniauth 0.3.3" to match what we currently use. The gurus postulate we can probably use the security upgrades in OmniAuth 2.0 this way without having to do a full upgrade this very second, since the changes to achieve the security upgrade were non-intrusive. Here's the diff between the safe version we forked and the version we currently use in Wealthbox: https://github.com/synth/omniauth-microsoft_graph/compare/0.3.3...main