### PR TITLE
Fix domain verification error handling using CallbackError

### DIFF
--- a/lib/omniauth/microsoft_graph/domain_verifier.rb
+++ b/lib/omniauth/microsoft_graph/domain_verifier.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 require 'jwt' # for token signature validation
-require 'omniauth' # to inherit from OmniAuth::Error
+require 'omniauth-oauth2' # to use CallbackError
 require 'oauth2' # to rescue OAuth2::Error
 
 module OmniAuth
@@ -10,8 +11,6 @@ module OmniAuth
     # https://clerk.com/docs/authentication/social-connections/microsoft#stay-secure-against-the-n-o-auth-vulnerability
     OIDC_CONFIG_URL = 'https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration'
     COMMON_JWKS_URL = 'https://login.microsoftonline.com/common/discovery/v2.0/keys'
-
-    class DomainVerificationError < OmniAuth::Error; end
 
     class DomainVerifier
       def self.verify!(auth_hash, access_token, options)
@@ -41,7 +40,13 @@ module OmniAuth
           skip_verification == true ||
           (skip_verification.is_a?(Array) && skip_verification.include?(email_domain)) ||
           domain_verified_jwt_claim
-        raise DomainVerificationError, verification_error_message
+
+        # Use CallbackError to ensure the error is properly caught by the callback_phase
+        # rescue clause and converted to an OmniAuth failure instead of bubbling up as a 500 error.
+        raise OmniAuth::Strategies::OAuth2::CallbackError.new(
+          :domain_verification_failed,
+          verification_error_message
+        )
       end
 
       private

--- a/spec/omniauth/microsoft_graph/domain_verifier_spec.rb
+++ b/spec/omniauth/microsoft_graph/domain_verifier_spec.rb
@@ -105,8 +105,11 @@ RSpec.describe OmniAuth::MicrosoftGraph::DomainVerifier do
     context 'when all verification strategies fail' do
       before { allow(access_token).to receive(:get).and_raise(::OAuth2::Error.new('whoops')) }
 
-      it 'raises a DomainVerificationError' do
-        expect { result }.to raise_error OmniAuth::MicrosoftGraph::DomainVerificationError
+      it 'raises a CallbackError with domain_verification_failed' do
+        expect { result }.to raise_error(OmniAuth::Strategies::OAuth2::CallbackError) do |error|
+          expect(error.error).to eq(:domain_verification_failed)
+          expect(error.error_reason).to include('not a verified domain')
+        end
       end
     end
   end

--- a/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
+++ b/spec/omniauth/strategies/microsoft_graph_oauth2_spec.rb
@@ -282,7 +282,12 @@ describe OmniAuth::Strategies::MicrosoftGraph do
 
     context 'when email verification fails' do
       let(:response_hash) { { mail: 'something@domain.invalid' } }
-      let(:error) { OmniAuth::MicrosoftGraph::DomainVerificationError.new }
+      let(:error) do
+        OmniAuth::Strategies::OAuth2::CallbackError.new(
+          :domain_verification_failed,
+          'Domain verification failed'
+        )
+      end
 
       before do
         allow(OmniAuth::MicrosoftGraph::DomainVerifier).to receive(:verify!).and_raise(error)


### PR DESCRIPTION
## Problem

Users experiencing domain verification failures currently see **500 Internal Server Errors** instead of proper authentication failure messages. This creates a poor user experience and makes debugging difficult, as errors appear in exception tracking systems rather than being handled gracefully through OmniAuth's failure callback mechanism.

## Solution

Replace the custom `DomainVerificationError` class with `OmniAuth::Strategies::OAuth2::CallbackError` to ensure proper error handling.

## Key Changes

- Removes custom `DomainVerificationError` class (inherited from `OmniAuth::Error`)
- Uses `OmniAuth::Strategies::OAuth2::CallbackError` for domain verification failures
- Updates tests to expect `CallbackError` with `:domain_verification_failed` symbol
- Changes require statement from `omniauth` to `omniauth-oauth2`

## Rationale

The omniauth-oauth2 gem's `callback_phase` only rescues specific exceptions:

```ruby
rescue ::OAuth2::Error, CallbackError => e
  fail!(:invalid_credentials, e)
end
```

The previous `DomainVerificationError` inherited from `OmniAuth::Error`, which is **not** in this rescue clause, causing it to bubble up as an unhandled 500 error.

By using `CallbackError`, the error is:
- ✅ Caught by the existing rescue clause
- ✅ Converted to an OmniAuth failure automatically  
- ✅ Redirected to the failure path with a proper error message

## Pattern Consistency

This follows the established pattern used by omniauth-google-oauth2 for hosted domain verification, ensuring consistency across the OmniAuth ecosystem.

## Error Handling Flow

**Before (❌):**
```
Domain verification fails → DomainVerificationError → Not caught → 500 error
```

**After (✅):**
```
Domain verification fails → CallbackError → Caught by rescue → OmniAuth failure callback → User-friendly error
```

## Testing

Updated test in `domain_verifier_spec.rb`:
- Expects `CallbackError` with `:domain_verification_failed` symbol
- Verifies error message includes "not a verified domain"
- Ensures structured error data for proper handling

## Compatibility

✅ **Backward compatible** - Applications using this gem don't need code changes. The error is still caught and handled through OmniAuth's standard failure mechanism.
