### PR TITLE
Relax version constraint for jwt gem

### DIFF
--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'jwt', '~> 2.0'
+  spec.add_runtime_dependency 'jwt', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
   spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
   spec.add_development_dependency "sinatra", '~> 2.2'


### PR DESCRIPTION
Before this commit adding this gem downgraded JWT from 3.1.x to 2.x. for our app. Tests are passing with JWT 3.1.2, the latest version.