### PR TITLE
Loosen omniauth-oauth2 dependency to allow < 2.0

### DIFF
--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jwt', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8', '< 2.0'
   spec.add_development_dependency "sinatra", '~> 4.1'
   spec.add_development_dependency "rake", '~> 12.3.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/omniauth-microsoft_graph.gemspec
+++ b/omniauth-microsoft_graph.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jwt', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8', '< 2.0'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.8'
   spec.add_development_dependency "sinatra", '~> 4.1'
   spec.add_development_dependency "rake", '~> 12.3.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
Allows for depending on the fairly old at this point 1.9: https://github.com/omniauth/omniauth-oauth2/releases/tag/v1.9.0

Mainly has fixes for CSRF timing attack and support for Ruby 3.2 in their CI